### PR TITLE
Added Llama3.2 3b model

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 - [Stable Diffusion Turbo Pipeline](https://github.com/noryev/module-sdxl-ipfs)
 - [Falcon 7b](https://github.com/narbs91/lilypad-falcon-7b-instruct-module)
 - [Llama2](https://github.com/noryev/module-llama2)
+- [Llama3.2 3b](https://github.com/rhochmayr/ollama-llama3.2-3b)
 - [Stable Diffusion Turbo](https://docs.lilypad.tech/lilypad/lilypad-modules/stable-diffusion-turbo-pipeline)
 - [Stable Diffusion XL](https://github.com/Lilypad-Tech/lilypad-module-sdxl-pipeline/)
 - [Stable Diffusion Video](https://github.com/Lilypad-Tech/lilypad-module-sdv-pipeline)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A list of modules that can run on the Lilypad Network provided by the Lilypad te
 - [Stable Diffusion Turbo](https://docs.lilypad.tech/lilypad/lilypad-modules/stable-diffusion-turbo-pipeline)
 - [Falcon 7b](https://github.com/narbs91/lilypad-falcon-7b-instruct-module)
 - [Llama2](https://github.com/noryev/module-llama2)
-- [Llama3.2 3b](https://github.com/rhochmayr/ollama-llama3.2-3b)
+- [Llama3.2 3b](https://github.com/rhochmayr/ollama-llama3.2-3b/tree/0.1.6)
 - [Stable Diffusion XL](https://github.com/Lilypad-Tech/lilypad-module-sdxl-pipeline/)
 - [Stable Diffusion Video](https://github.com/Lilypad-Tech/lilypad-module-sdv-pipeline)
 - [wasm](https://github.com/lilypad-tech/lilypad-module-wasm)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ A list of modules that can run on the Lilypad Network provided by the Lilypad te
 - [Falcon 7b](https://github.com/narbs91/lilypad-falcon-7b-instruct-module)
 - [Llama2](https://github.com/noryev/module-llama2)
 - [Llama3.2 3b](https://github.com/rhochmayr/ollama-llama3.2-3b)
-- [Stable Diffusion Turbo](https://docs.lilypad.tech/lilypad/lilypad-modules/stable-diffusion-turbo-pipeline)
 - [Stable Diffusion XL](https://github.com/Lilypad-Tech/lilypad-module-sdxl-pipeline/)
 - [Stable Diffusion Video](https://github.com/Lilypad-Tech/lilypad-module-sdv-pipeline)
 - [wasm](https://github.com/lilypad-tech/lilypad-module-wasm)


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Added Llama3.2 Model (3B) served with Ollama.

Module creation as part of the Lilypad Module Creator Rewards.

### Task/Issue reference

N/A

### Test plan

```
lilypad --network demonet run github.com/rhochmayr/ollama-llama3.2-3b:0.1.6 -i Prompt="How does a SSL handshake work?"
```

### Details (optional)

The Meta Llama 3.2 collection of multilingual large language models (LLMs) is a collection of pretrained and instruction-tuned generative models in 1B and 3B sizes (text in/text out). The Llama 3.2 instruction-tuned text only models are optimized for multilingual dialogue use cases, including agentic retrieval and summarization tasks. They outperform many of the available open source and closed chat models on common industry benchmarks.

#### Model size
3B parameters (default)

The 3B model outperforms the Gemma 2 2.6B and Phi 3.5-mini models on tasks such as:

- Following instructions
- Summarization
- Prompt rewriting
- Tool use

https://github.com/rhochmayr/ollama-llama3.2-3b/

### Related issues or PRs (optional)

N/A