### PR TITLE
Added DeepSeek-R1 7b model

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 - [Stable Diffusion Turbo Pipeline](https://github.com/noryev/module-sdxl-ipfs)
 - [Falcon 7b](https://github.com/narbs91/lilypad-falcon-7b-instruct-module)
 - [Llama2](https://github.com/noryev/module-llama2)
+- [Llama3.2 3b](https://github.com/rhochmayr/ollama-llama3.2-3b)
 - [Stable Diffusion Turbo](https://docs.lilypad.tech/lilypad/lilypad-modules/stable-diffusion-turbo-pipeline)
 - [Stable Diffusion XL](https://github.com/Lilypad-Tech/lilypad-module-sdxl-pipeline/)
 - [Stable Diffusion Video](https://github.com/Lilypad-Tech/lilypad-module-sdv-pipeline)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ A list of modules that can run on the Lilypad Network provided by the Lilypad te
 - [Falcon 7b](https://github.com/narbs91/lilypad-falcon-7b-instruct-module)
 - [Llama2](https://github.com/noryev/module-llama2)
 - [Llama3.2 3b](https://github.com/rhochmayr/ollama-llama3.2-3b)
-- [Stable Diffusion Turbo](https://docs.lilypad.tech/lilypad/lilypad-modules/stable-diffusion-turbo-pipeline)
 - [Stable Diffusion XL](https://github.com/Lilypad-Tech/lilypad-module-sdxl-pipeline/)
 - [Stable Diffusion Video](https://github.com/Lilypad-Tech/lilypad-module-sdv-pipeline)
 - [wasm](https://github.com/lilypad-tech/lilypad-module-wasm)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ A list of modules that can run on the Lilypad Network provided by the Lilypad te
 - [cowsay](https://github.com/lilypad-tech/lilypad-module-cowsay)
 - [Stable Diffusion Turbo Pipeline](https://github.com/noryev/module-sdxl-ipfs)
 - [Stable Diffusion Turbo](https://docs.lilypad.tech/lilypad/lilypad-modules/stable-diffusion-turbo-pipeline)
+- [DeepSeek-R1 7b](https://github.com/rhochmayr/ollama-deepseek-r1-7b)
 - [Falcon 7b](https://github.com/narbs91/lilypad-falcon-7b-instruct-module)
 - [Llama2](https://github.com/noryev/module-llama2)
 - [Llama3.2 3b](https://github.com/rhochmayr/ollama-llama3.2-3b)


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Added DeepSeek-R1 Model (7B) served with Ollama.

Module creation as part of the  Lilypad module creator program

### Task/Issue reference

N/A

### Test plan

```
lilypad run --network demonet github.com/rhochmayr/ollama-deepseek-r1-7b:1.0.0 -i Prompt="There are 49 dogs signed up for a dog show. There are 36 more small dogs than large dogs. How
many small dogs have signed up to compete?"
```

### Details (optional)

DeepSeek's first-generation of reasoning model, achieving performance comparable to OpenAI-o1 across math, code, and reasoning tasks. 

#### Distilled model

DeepSeek team has demonstrated that the reasoning patterns of larger models can be distilled into smaller models, resulting in better performance compared to the reasoning patterns discovered through RL on small models.

This is the 7B model created via fine-tuning against a dense model (Qwen) widely used in the research community using reasoning data generated by DeepSeek-R1

https://github.com/rhochmayr/ollama-deepseek-r1-7b

### Related issues or PRs (optional)

N/A