### PR TITLE
Added Qwen2.5-Coder 7b model

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ A list of modules that can run on the Lilypad Network provided by the Lilypad te
 - [Falcon 7b](https://github.com/narbs91/lilypad-falcon-7b-instruct-module)
 - [Llama2](https://github.com/noryev/module-llama2)
 - [Llama3.2 3b](https://github.com/rhochmayr/ollama-llama3.2-3b)
+- [Qwen2.5-Coder 7b](https://github.com/rhochmayr/ollama-qwen2.5-coder-7b)
 - [Stable Diffusion XL](https://github.com/Lilypad-Tech/lilypad-module-sdxl-pipeline/)
 - [Stable Diffusion Video](https://github.com/Lilypad-Tech/lilypad-module-sdv-pipeline)
 - [wasm](https://github.com/lilypad-tech/lilypad-module-wasm)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 - [Stable Diffusion Turbo Pipeline](https://github.com/noryev/module-sdxl-ipfs)
 - [Falcon 7b](https://github.com/narbs91/lilypad-falcon-7b-instruct-module)
 - [Llama2](https://github.com/noryev/module-llama2)
+- [Llama3.2 3b](https://github.com/rhochmayr/ollama-llama3.2-3b)
 - [Stable Diffusion Turbo](https://docs.lilypad.tech/lilypad/lilypad-modules/stable-diffusion-turbo-pipeline)
 - [Stable Diffusion XL](https://github.com/Lilypad-Tech/lilypad-module-sdxl-pipeline/)
 - [Stable Diffusion Video](https://github.com/Lilypad-Tech/lilypad-module-sdv-pipeline)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ A list of modules that can run on the Lilypad Network provided by the Lilypad te
 - [Falcon 7b](https://github.com/narbs91/lilypad-falcon-7b-instruct-module)
 - [Llama2](https://github.com/noryev/module-llama2)
 - [Llama3.2 3b](https://github.com/rhochmayr/ollama-llama3.2-3b)
-- [Stable Diffusion Turbo](https://docs.lilypad.tech/lilypad/lilypad-modules/stable-diffusion-turbo-pipeline)
 - [Stable Diffusion XL](https://github.com/Lilypad-Tech/lilypad-module-sdxl-pipeline/)
 - [Stable Diffusion Video](https://github.com/Lilypad-Tech/lilypad-module-sdv-pipeline)
 - [wasm](https://github.com/lilypad-tech/lilypad-module-wasm)


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Added Qwen2.5-Coder Model (7B) served with Ollama.

Module creation as part of the Lilypad module creator program

### Task/Issue reference

N/A

### Test plan

```
lilypad run --network demonet github.com/rhochmayr/ollama-qwen2.5-coder-7b:1.0.0 -i Prompt="write a quick sort algorithm"
```

### Details (optional)

The latest series of Code-Specific Qwen models, with significant improvements in code generation, code reasoning, and code fixing.

https://github.com/rhochmayr/ollama-qwen2.5-coder-7b

### Related issues or PRs (optional)

N/A